### PR TITLE
add: set git not to track changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 .tern-port
 
 build
+
+# ignoring docusaurus config files accross different environments
+.docusaurus


### PR DESCRIPTION
I noticed that, once the content is being added to the repo, there are a lot of files being changed. And that's as a result of git's tracking of the config files of docusaurus. 

It was among the reasons why I had multiple failed builds, when i was trying to review and merge the changes made by the contributors.

I've asked git to ignore the files BTW